### PR TITLE
Fixed Youtube link

### DIFF
--- a/IntroToTextAnalytics_Part1.R
+++ b/IntroToTextAnalytics_Part1.R
@@ -19,7 +19,7 @@
 # This R source code file corresponds to video 1 of the Data Science
 # Dojo YouTube series "Introduction to Text Analytics with R" located 
 # at the following URL:
-#     <YouTube Video Link Here />     
+#     https://www.youtube.com/watch?v=4vuw0AsHeGw   
 #
 
 


### PR DESCRIPTION
Was a placeholder for the actual Youtube video. Changed it to the link for the actual Youtube video. This is the only one of the R scripts to still have the placeholder.